### PR TITLE
events: update lead text

### DIFF
--- a/source/events.html.erb
+++ b/source/events.html.erb
@@ -53,7 +53,11 @@ description: Supporting quotes from OpenShift Commons participants.
             <span>Great</span>
             Sessions
           </h3>
-          <p>We're constantly planning new events for all types of interests. Each event is lead by an OpenShift expert and would love to answer any of your questions. All times listed are in Pacific Standard Time. </p>
+          <p>
+            <strong>All times listed are in Pacific Standard Time.</strong>
+            Each event is lead by an OpenShift expert who would love to answer any of your questions. All the OpenShift Commons Briefings and are recorded and posted on
+            <a href="https://www.youtube.com/playlist?list=PLaR6Rq6Z4IqdIM7LtosKqi3LlYXyxjwnj" target="_blank">our YouTube channel</a>.
+          </p>
           <ul class="list">
             <li>
               <i class="fa fa-check"></i>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -57,6 +57,9 @@ description:  Where users, partners, customers, and contributors come together t
           </div>
         </div>
         <div class="row">
+          <div class="col-md-12 text-center">
+            <p class="small"><strong>All times listed are in Pacific Standard Time.</strong></p>
+          </div>
           <div class="col-md-4 col-md-offset-4 col-xs-10 col-xs-offset-1 text-center more-btn" id="more-events-btn">
             <a class="btn btn-primary" href="events.html">More Briefings&nbsp;<i class="fa fa-arrow-right" aria-hidden="true"></i></a>
           </div>


### PR DESCRIPTION
* highlights that times are in PST, adds YT link, closes #690
* the PST note is added to the index page, below the calendar view

Requested-by: Diane Mueller-Klingspor
Signed-off-by: Jiri Fiala <jfiala@redhat.com>