### PR TITLE
sig: add a new Operator Framework SIG

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -275,6 +275,20 @@ description:  Where users, partners, customers, and contributors come together t
               </div>
             </div>
           </div>
+          <div class="row ">
+            <div class="paddings">
+              <div class="col-xs-12 col-sm-6 col-sm-offset-3 wow fadeInRight">
+                <h2>
+                  <a href="/sig/OpenshiftOperators.html" title="Operator Framework">Operator Framework</a>
+                  <p>
+                    The Operator Framework is an open source toolkit to manage Kubernetes native applications, called Operators,
+                    in an effective, automated, and scalable way. This SIG will discuss, develop and disseminate best practices
+                    for building and managing Operators.
+                  </p>
+                </h2>
+              </div>
+            </div>
+          </div>
       </div>
       <i class="fa fa-comments-o right"></i>
     </div>

--- a/source/sig/OpenshiftOperators.html.erb
+++ b/source/sig/OpenshiftOperators.html.erb
@@ -1,0 +1,77 @@
+---
+title: Operator Framework
+description: The Operator Framework is an open source toolkit to manage Kubernetes native applications, called Operators, in an effective, automated, and scalable way. This SIG will discuss, develop and disseminate best practices for building and managing Operators.
+---
+
+<% content_for :header do %>
+<h1 class="animated fadeInDown delay">
+  Operator Framework
+</h1>
+<p class="animated fadeInUp delay">
+  The principal purpose of the Operator Framework SIG is to discuss, develop and disseminate best practices for building Operators, using Operators and help grow
+  the Operator ecosystem by engaging and learning from Operator authors, users and contributors to the Operator Framework itself.
+</p>
+<% end %>
+
+<div class="crumbs border_bottom">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <ul>
+          <li>
+            <a href="/index.html">Home</a>
+          </li>
+          <li>/</li>
+          <li>
+            <a href="/sig/OpenshiftOperators.html">Operator Framework</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section class="content_info" id="join">
+  <div class="info_title wow fadeInDown" id="try">
+    <i class="fa fa-users right"></i>
+    <div class="vertical_line">
+      <div class="circle_bottom"></div>
+    </div>
+    <div class="info_vertical animated">
+      <h1>
+        Join the Operator Framework
+        <br>
+        <span>Special Interest Group</span>
+      </h1>
+    </div>
+    <div class="padding_bottom">
+      <div class="container wow fadeInUp animated">
+        <div class="row">
+          <div class="col-xs-12 col-sm-12 col-md-6 col-md-offset-3 text-center">
+            <%= partial "forms/sig_universal" %>
+          </div>
+        </div>
+        <div id="result-newsletter"></div>
+      </div>
+    </div>
+  </div>
+</section>
+<hr style="margin:0;">
+<section class="content_info" id="colleagues">
+  <div class="vertical_line">
+    <div class="circle_bottom"></div>
+  </div>
+  <div class="row info_title wow fadeInUp">
+    <div class="info_vertical animated">
+      <h1>
+        Operator Framework
+        <span>Articles</span>
+      </h1>
+    </div>
+  </div>
+  <div class="container wow fadeInUp">
+    <div class="row-fluid">
+      <%= partial "sig/operators_articles" %>
+    </div>
+  </div>
+</section>

--- a/source/sig/_operators_articles.erb
+++ b/source/sig/_operators_articles.erb
@@ -1,0 +1,45 @@
+<% content_for :javascript do %>
+$(document).ready(function () {
+  var feedUrl = 'https://blog.openshift.com/tag/operators/feed/';
+  var numItems = 10;
+  var blogFeedContainer = $("#blog-feed-sig");
+
+  var blogItemHtml = function(link, title, author, date, description) {
+    var blogDate = new Date(date);
+    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
+    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
+    return htmlTemplate;
+  };
+
+  $.ajax({
+    url: "https://query.yahooapis.com/v1/public/yql",
+    jsonp: "callback",
+    dataType: "jsonp",
+    data: {
+        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
+        format: "json"
+    },
+    error: function() {
+      console.log("Error occurred while getting blog RSS feed!");
+    },
+    success: function( response ) {
+      var output = '';
+      $(response.query.results.item).each(function(index, entry) {
+        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
+      });
+      blogFeedContainer.html(output);
+    },
+    complete: function() {
+      $("#blog-feed-sig .blog-article").matchHeight();
+    }
+  });
+});
+<% end %>
+
+<div id="blog-feed-sig">
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <i class="fa fa-cog fa-spin fa-2x" aria-hidden="true"></i>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
A preview is available [here](https://com-stage-pro.b9ad.pro-us-east-1.openshiftapps.com/). Before deploying this PR, we may want to wait for confirmation the universal Eloqua form is processing the new page parameter (`OpenshiftOperators.html`) properly. I'll send a separate email to those who were involved before, to have this synced.

* adds a new Operator Framework SIG page, closes #709 

Requested-by: Diane Mueller-Klingspor
Signed-off-by: Jiri Fiala <jfiala@redhat.com>