### PR TITLE
Adding sponsors for Seattle

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -31,6 +31,10 @@ gatherings:
     sponsors:
       - name: "StorageOS"
       - name: "Tremolo Security"
+      - name: "Instana"
+      - name: "Pure Storage"
+      - name: "ProphetStor"
+      - name: "Twistlock" 
     sponsoring_URL: "https://openshiftgathering.com/openshiftgathering_sponsors_application"
     schedule:
       - local_time: "8:00 am"


### PR DESCRIPTION
Added Instana, Pure Storage, ProphetStor, and Twistlock as sponsors