### PR TITLE
changed Partners to New Members

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ $ git fetch upstream
 ```
 
 
-## Adding partners
+## Adding New Members
 
-Currently the most common task is to add partners' information to the website, i.e., 
+Currently the most common task is to add members' information to the website, i.e., 
 their logo, name, and url. You can check if any there's any logo waiting to be added 
 on this repository's [issues](https://github.com/openshift-cs/commons.openshift.org/issues).
 


### PR DESCRIPTION
Commons is made up of users, contributors, upstream projects, service providers, isv and partners - so it's more accurate to use the term members here