### PR TITLE
gatherings: add expiration check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,11 @@ gatherings:
     menu: "show" (is not in the site menu, if "show" is not here or the build date of this site is in future
                  compared with the event date below)
     language: "English" (optional)
-    date: "2018-12-10"
+    date: "2018-12-10" (once this is detected to be in past, compared with user's local time, obsolete page sections
+                       are "disabled" and a notice is displayed)
     time: "8:00 am - 5:30 pm"
+    youtube_playlist_id: "PLaR6Rq6Z4IqcrUvqDVPe5DxNvJp5s8UXC" (optional; an ID of a youtube video playlist with
+                          talks' recordings to be linked to, if the event is over)
     location: "Seattle, Washington"
     google_maps_URL: >-
       Start content here

--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -101,6 +101,7 @@ gatherings:
     language: "English"
     date: "2018-9-10"
     time: "9:00 am - 8:00 pm"
+    youtube_playlist_id: "PLaR6Rq6Z4IqcrUvqDVPe5DxNvJp5s8UXC"
     location: "Helsinki, Finland"
     google_maps_URL: >-
       <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d992.1460258186596!2d24.82946665733454!3d60.17589808196301!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x468df58ef3269a05%3A0xa379bbde9aacb411!2sKeilaranta+1%2C+02150+Espoo!5e0!3m2!1sen!2sfi!4v1530528575622" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
@@ -120,9 +121,6 @@ gatherings:
       The OpenShift Commons Gathering brings together experts from all over the world to discuss container technologies, best practices for cloud native application developers and
       the open source software projects that underpin the OpenShift ecosystem. The Helsinki event will gather developers, devops professionals and sysadmins together to explore
       the next steps in making container technologies successful and secure.
-    event_footer_text: >-
-      <strong>This event is now over</strong>, all of the presenations were recorded and are available on <a href="https://www.youtube.com/channel/UCZKMj3YI0wP-kq4QYpaKdEA" target="_blank">our Youtube channel</a>
-      in <a href="https://www.youtube.com/playlist?list=PLaR6Rq6Z4IqcrUvqDVPe5DxNvJp5s8UXC" target="_blank"><strong>this playlist</strong></a>.
     invite_link: "https://docs.google.com/forms/d/e/1FAIpQLSfHDndcqfnU8y6X58e0GbfqHNxWPrX1qg2REH9tin-zqjJSkw/viewform"
     sponsors:
       - name: "microsoft-helsinki"

--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -958,7 +958,18 @@ ul.operators.list {
 .ocg-img {
 	margin-bottom: 30px;
 }
+.section-gathering {
+	a.obsolete {
+		color: grey;
+		text-decoration: none;
+	}
+}
 .btn-event {
+
+  &.obsolete {
+		display: none;
+	}
+
 	padding:15px 10px;
 	margin-left:auto;
 	margin-right:auto;
@@ -989,6 +1000,11 @@ border: 2px solid rgb(100, 149, 237);
 background: #DB212F;
 border: 2px solid #DB212F;
 }
+#gathering-over-notice {
+	background-color: rgb(255, 210, 78);
+	display: none;
+	padding-top: 20px;
+}
 .event-box {
 border: 1px solid #eee;
 background: #FFF;
@@ -1007,6 +1023,9 @@ min-height: 138px;
 		width: 100%;
 	}
 }
+.sponsoring-invite.obsolete {
+	display: none;
+}
 .event-overview {
 font-size:18px;
 margin: 0 20px;
@@ -1014,9 +1033,15 @@ margin: 0 20px;
 .event-span-red {
 	color: #DB212F;
 	font-weight:700;
+	&.obsolete {
+		color: grey;
+	}
 }
 .event-invite {
 	font-size:1.2em;
+	a {
+		display: none;
+	}
 }
 
 #price {
@@ -1025,6 +1050,9 @@ margin: 0 20px;
 	}
   p {
 		margin-bottom: 10px;
+		&.obsolete {
+      text-decoration: line-through grey;
+		}
 	}
 }
 
@@ -1040,6 +1068,10 @@ margin: 0 20px;
 .section-gathering {
 	padding-bottom: 60px;
 	padding-top: 60px;
+
+	a.obsolete {
+		color: gray;
+	}
 
 	&>.event-footer-text {
 	  padding-top: 40px;
@@ -1097,7 +1129,7 @@ position:relative;
   -webkit-backface-visibility: hidden;
   -webkit-transform: rotate(0deg) skewY(0deg);
   -webkit-transform-origin: 50% 10%;
-  transform-origin: 50% 10%;
+	transform-origin: 50% 10%;
 
 	* {
 		display: block;
@@ -1116,6 +1148,10 @@ position:relative;
 		background-color: #DB212F;
 		outline-style: dotted;
 		box-shadow: 0 2px 0 red;
+		&.obsolete {
+			background-color: grey;
+			box-shadow: 0 2px 0 grey;
+		}
 	}
 
 	em {

--- a/source/gatherings/template.html.erb
+++ b/source/gatherings/template.html.erb
@@ -393,9 +393,10 @@ description:  The OpenShift Commons community gets together and share experience
     $('.speaker-container').matchHeight();
 
     // grey out and "deactivate" obsolete elements if the event already started
-    var eventDate = new Date("<%= gathering.date.to_time.iso8601() %>");
-    if (Date.now() > eventDate) {
-      console.log("Detected event date: " + eventDate);
+    <% require 'active_support/time' %>
+    var eventDatePlusOne = new Date("<%= gathering.date.to_time.tomorrow.iso8601() %>");
+    if (Date.now() > eventDatePlusOne) {
+      console.log("Detected day following the event start date: " + eventDatePlusOne);
       $(".obsoletes").addClass("obsolete");
       $(".obsoletes").find("*").addClass("obsolete");
       $(".obsoletes").find("a").removeAttr("href");

--- a/source/gatherings/template.html.erb
+++ b/source/gatherings/template.html.erb
@@ -62,7 +62,7 @@ description:  The OpenShift Commons community gets together and share experience
     <% else %>
     <div class="col-sm-4 col-sm-offset-4">
     <% end %>
-      <div class="btn-event event-border buy">
+      <div class="btn-event event-border buy obsoletes">
         <a href="<%= gathering.registration_URL %>" target="_blank">
           <p class="text-center">
             <% if gathering.registration_text.presence && gathering.registration_text.length > 0 %>
@@ -80,7 +80,7 @@ description:  The OpenShift Commons community gets together and share experience
     </div>
     <% if gathering.sponsoring_URL.presence && gathering.sponsoring_URL.length > 0 %>
     <div class="col-sm-4">
-      <div class="btn-event apply">
+      <div class="btn-event apply obsoletes">
         <a href="<%= gathering.sponsoring_URL %>" target="_blank">
           <p class="text-center"><%= gathering.sponsor_button_text.presence ? gathering.sponsor_button_text : 'Apply to be a sponsor' %></p>
         </a>
@@ -90,6 +90,24 @@ description:  The OpenShift Commons community gets together and share experience
   </div><!-- /.row -->
 </div><!-- /.container-->
 <br>
+<!-- -->
+<section id="gathering-over-notice">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12 text-center">
+        <p>
+          <strong>This event is now over</strong>!
+          <% if gathering.youtube_playlist_id.presence && gathering.youtube_playlist_id.length > 0 %>
+            All of the presenations were recorded and are available on
+            <a href="https://www.youtube.com/channel/UCZKMj3YI0wP-kq4QYpaKdEA" target="_blank">our Youtube channel</a> in
+            <a href="https://www.youtube.com/playlist?list=<%= gathering.youtube_playlist_id %>" target="_blank">
+            <strong>this playlist</strong></a>.
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
 <!-- Overview Section ----------------------------------------------------------------------------------------------------------->
 <div id="gathering-overview"></div>
 <section class="section-gathering section-gathering-secondary">
@@ -98,7 +116,7 @@ description:  The OpenShift Commons community gets together and share experience
       <div class="container">
         <h3 class="text-center"><%= gathering.headers.presence && gathering.headers.overview.presence ? gathering.headers.overview : 'Event Overview' %></h3><br>
         <!-- Overview Box -->
-        <div class="col-md-12 event-box">
+        <div class="col-md-12 event-box obsoletes">
           <!-- Left Col -->
           <div class="col-md-6 text-center">
             <% if gathering.lead_text.presence && gathering.lead_text.length > 0 %>
@@ -196,7 +214,7 @@ description:  The OpenShift Commons community gets together and share experience
         <div class="row container text-center">
             <h3><%= gathering.headers.presence && gathering.headers.sponsors.presence ? gathering.headers.sponsors : 'Sponsors' %></h3>
             <% if gathering.sponsoring_URL.presence && gathering.sponsoring_URL.length > 0 %>
-            <p class="text-center">Interested in sponsoring OpenShift Commons Gathering?
+            <p class="text-center sponsoring-invite obsoletes">Interested in sponsoring OpenShift Commons Gathering?
               <a href="<%= gathering.sponsoring_URL %>" target="_blank">Apply here.</a>
             </p>
             <% end %>
@@ -212,9 +230,9 @@ description:  The OpenShift Commons community gets together and share experience
               </div>
             <% end %>
             <% if gathering.sponsoring_URL.presence && gathering.sponsoring_URL.length > 0 %>
-            <div class="sponsor sponsor-height col-xs-6 col-md-3">
+            <div class="sponsor sponsor-height col-xs-6 col-md-3 sponsoring-invite obsoletes">
               <div class="panel-body">
-                <a href = "<%= gathering.sponsoring_URL %>" target = "_blank">
+                <a href = "<%= gathering.sponsoring_URL %>" target = "_blank" class="obsoletes">
                   <strong>Your logo here?</strong>
                 </a>
               </div>
@@ -260,7 +278,7 @@ description:  The OpenShift Commons community gets together and share experience
               </div><!-- /.schedule box <-->
           </div><!-- /.container -->
           <br><br>
-          <div class="btn-event event-border buy">
+          <div class="btn-event event-border buy obsoletes">
             <a href="<%= gathering.registration_URL %>" target="_blank">
               <p class="text-center">
                 <% if gathering.registration_text.presence && gathering.registration_text.length > 0 %>
@@ -373,5 +391,16 @@ description:  The OpenShift Commons community gets together and share experience
 
     // match height of speaker icons
     $('.speaker-container').matchHeight();
+
+    // grey out and "deactivate" obsolete elements if the event already started
+    var eventDate = new Date("<%= gathering.date.to_time.iso8601() %>");
+    if (Date.now() > eventDate) {
+      console.log("Detected event date: " + eventDate);
+      $(".obsoletes").addClass("obsolete");
+      $(".obsoletes").find("*").addClass("obsolete");
+      $(".obsoletes").find("a").removeAttr("href");
+      $("#gathering-over-notice").show();
+    }
+
   })
 </script>

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -34,7 +34,7 @@ $(document).ready(function($) {
 			case '/events.html':
 				elem.text = 'Briefing Events';
 				break;
-			case '/briefings.html':
+			case 'https://www.youtube.com/user/rhopenshift/playlists?flow=grid&view=1':
 				elem.text = 'Briefing Videos';
 				break;
 			case '/videos.html':

--- a/source/layouts/_navbar.erb
+++ b/source/layouts/_navbar.erb
@@ -23,7 +23,7 @@
               </li>
               <li>
                 <%# This text is override on Mobile in main.js %>
-                <a href="https://www.youtube.com/user/rhopenshift/playlists?flow=grid&view=1">Past Videos</a>
+                <a href="https://www.youtube.com/user/rhopenshift/playlists?flow=grid&view=1"><i class="fa fa-youtube"></i> Past Videos</a>
               </li>
             </ul>
           </li>
@@ -40,7 +40,7 @@
               <% end %>
               <li>
                 <%# This text is override on Mobile in main.js %>
-                <a href="/videos.html">Past Videos</a>
+                <a href="/videos.html"><i class="fa fa-video-camera"></i> Past Videos</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
For gathering events that have start date in past, a note and playlist link (if specified in `gatherings.yml`) are added. Also removes sponsoring links, strikes through the price(s), greys out the event overview section and deactivates event overview links, but keeps speakers, schedule, venue (and relevant links).
This is deployed [here](https://com-stage-pro.b9ad.pro-us-east-1.openshiftapps.com/gatherings/Helsinki_2018.html) for preview.

Known issues:
- The date/time comparison is client zone dependent. Specifying the event end time accurately in the `gatherings.yml` is to be a future improvement. (For now, I simply do not expect "last minute" attendee and sponsor registrations on the event start date.)
- The playlist is limited to a single YouTube playlist ID only, rather than allowing any video hosting URL. This is going to simplify obsoleting the current `gathering_videos.yml` list.
- No multilingual support, the expiration notice is hardcoded in English.


------
* adds Commons Gathering events expiration functionality
* adds icons to Briefing and Gathering videos menu links
* fixes tinyNav Briefing Videos link caption

Signed-off-by: Jiri Fiala <jfiala@redhat.com>