### PR TITLE
resizer: download SVGs with the user-agent set

### DIFF
--- a/resizer/ImageResizer.java
+++ b/resizer/ImageResizer.java
@@ -53,11 +53,6 @@ public class ImageResizer {
     "url:\\s*(?<url>.*(?= logo))\\s*" + // Match the second line as containing the "url" information, use lookahead to ensure we don't match "logo"
     "logo:\\s*(?:(?=!\\[)!\\[.*]\\((?<logo1>[^\"\\s]*)\\)|(?<logo2>[^\"\\s]*))(?:\"|\\s*.*)"; // Match the third line as containing the "logo" information. Using a conditional (as a non-capturing group), we're able to differentiate embedded images from logo URLs
 
-  /**
-   * Discretionary number of milliseconds the copyURLToFile method will run until timeout, 10 seconds
-   */
-  private static final int TIMEOUT_MILLIS = 10000;
-
   /** Sending user agent prevents 403's when getting images from some servers **/
   private static final String USER_AGENT = "oscommonsbot/1.0";
 
@@ -403,13 +398,17 @@ public class ImageResizer {
 
     try {
       if (image == null) {
-        FileUtils.copyURLToFile(url, imageFile, TIMEOUT_MILLIS, TIMEOUT_MILLIS);
+        // avoid 403's by setting the user agent request header
+        URLConnection conn = url.openConnection();
+        conn.setRequestProperty("User-Agent", USER_AGENT);
+        FileUtils.copyInputStreamToFile(conn.getInputStream(), imageFile);
       } else {
         ImageIO.write(image, getExtension(url), imageFile);
       }
       return fileName;
     } catch (IOException e) {
       System.out.println("Error: Unable to write image for " + url + " to " + filePath + fileName);
+      System.out.println(e);
       return null;
     }
   }


### PR DESCRIPTION
This is something that I missed in #901 while looking on resized images, which is now causing trouble with #916 (svg). The same remedy should fix it here too.

---
* Uses the global USER_AGENT string when copying SVG images from URLs
* Removes TIMEOUT_MILLIS, that is not used now
* Prints out the actual exception when failing to write the image file

Signed-off-by: Jiri Fiala <jfiala@redhat.com>