### PR TITLE
add m3db desc

### DIFF
--- a/data/operators.yml
+++ b/data/operators.yml
@@ -223,7 +223,7 @@ vetted_operators:
   link: "https://github.com/m3db/m3"
   logo: "operators/m3db.png"
   logo_link: "https://github.com/m3db/m3/blob/master/README.md"
-  description: "Kubernetes operator for Sysdig Falco."
+  description: "The M3DB Operator is a project dedicated to setting up M3DB on Kubernetes. It aims to automate everyday tasks around managing M3DB. "
 - title: "VPC Peering"
   link: "https://github.com/pickledrick/vpc-peering-operator"
   logo: "operators/vpcpeering.png"


### PR DESCRIPTION
The M3DB Operator is a project dedicated to setting up M3DB on Kubernetes. It aims to automate everyday tasks around managing M3DB.