### PR TITLE
config: enable asset hashing

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -13,6 +13,9 @@ set :fonts_dir, 'fonts'
 set :images_dir, 'img'
 set :js_dir, 'js'
 
+# activate asset hashing to prevent obsolete cached assets be used
+activate :asset_hash
+
 ###
 # Page command
 ###


### PR DESCRIPTION
* Enables asset hashing to prevent old css/images/etc being used by
  local cache (mentioned in #964)

Signed-off-by: Jiri Fiala <jfiala@redhat.com>