### PR TITLE
repurpose the sponsors button for KOF workshop

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -547,9 +547,9 @@ gatherings:
       - name: "Crunchy"
       - name: "Devoteam"
       - name: "Dynatrace"
-    sponsoring_URL: "https://commons.openshift.org/gatherings/OpenShift_Commons_London_Sponsor.2019.pdf"
+    sponsoring_URL: "https://www.eventbrite.com/e/kubernetes-operators-framework-workshop-openshift-commons-gathering-tickets-54133545893"
     sponsor_button_text: >- 
-      Sponsorships are sold out!
+      Add-on Kubernetes Operator Workshop! 
     schedule:
       - local_time: "8:00 am"
         session_name: "Registration Opens"


### PR DESCRIPTION
repurpose the sponsors button for KOF workshop registration
https://www.eventbrite.com/e/kubernetes-operators-framework-workshop-openshift-commons-gathering-tickets-54133545893