### PR TITLE
index + sig: blog feed retrieval

### DIFF
--- a/source/_commons_articles.erb
+++ b/source/_commons_articles.erb
@@ -2,10 +2,10 @@
 // fetch openshift-commons tagged articles only
 $(document).ready(function () {
   var feedUrl = 'https://blog.openshift.com/category/openshift-commons/feed/';
-  var numItems = 6;
+  var maxItems = 6;
   var blogFeedContainer = $("#blog-feed");
 
-  var blogItemHtml = function(link, title, author, date) {
+  var blogItemHtml = function(link, title, date) {
     var blogDate = new Date(date);
     var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
     htmlTemplate = '<div class="col-xs-12"><div class="blog-article"><div class="row"><div class="blog-item"><a href="' + link + '">' + title + '</a><p class="small">' + blogDate.toLocaleDateString("en-us", dateFormat) + '</p></div></div></div></div>';
@@ -13,21 +13,20 @@ $(document).ready(function () {
   };
 
   $.ajax({
-    url: "https://query.yahooapis.com/v1/public/yql",
-    jsonp: "callback",
-    dataType: "jsonp",
-    data: {
-        q: 'select title, link, pubDate, dc:creator from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
-        format: "json"
-    },
+    url: feedUrl,
+    accepts:{
+			xml:"application/rss+xml"
+		},
+    dataType: "xml",
     error: function() {
-      console.log("Error occurred while getting blog RSS feed!");
+      console.log("Error occurred while getting blog RSS feed from " + this.url);
     },
-    success: function( response ) {
-      console.log(response);
-      var output = '';
-      $(response.query.results.item).each(function(index, entry) {
-        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate);
+    success: function(response) {
+      console.log("Blog feed retrieved.");
+      var output = "";
+      $(response).find("item").slice(0, maxItems).each(function () {
+				var el = $(this);
+        output += blogItemHtml(el.find("link").text(), el.find("title").text(), el.find("pubDate").text())
       });
       blogFeedContainer.html(output);
     }

--- a/source/js/rss-sig.js
+++ b/source/js/rss-sig.js
@@ -1,0 +1,31 @@
+// this function is used for rendering blog post links on SIG pages only
+function displayBlogPosts(feedUrl, maxItems, blogFeedContainer) {
+
+  var blogItemHtml = function(link, title, date, description) {
+    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
+    return htmlTemplate;
+  };
+
+  $.ajax({
+    url: feedUrl,
+    accepts:{
+			xml:"application/rss+xml"
+		},
+    dataType: "xml",
+    error: function() {
+      console.log("Error occurred while getting blog RSS feed from " + this.url);
+    },
+    success: function(response) {
+      console.log("Blog feed retrieved.");
+      var output = "";
+      $(response).find("item").slice(0, maxItems).each(function () {
+        var el = $(this);
+        output += blogItemHtml(el.find("link").text(), el.find("title").text(), el.find("pubDate").text(), el.find("description").text())
+      });
+      blogFeedContainer.html(output);
+    },
+    complete: function() {
+      $("#blog-feed-sig .blog-article").matchHeight();
+    }
+  });
+}

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -82,6 +82,7 @@
     <%= javascript_include_tag "bootstrap/bootstrap.js" %>
     <%= javascript_include_tag "match-height/jquery.matchHeight.js" %>
     <%= javascript_include_tag "main.js" %>
+    <%= javascript_include_tag "rss-sig.js" %>
 
     <script type="text/javascript">
       <%= content_for?(:javascript) ? yield_content(:javascript) : '' %>

--- a/source/sig/_big_data_articles.erb
+++ b/source/sig/_big_data_articles.erb
@@ -1,38 +1,6 @@
 <% content_for :javascript do %>
 $(document).ready(function () {
-  var feedUrl = 'https://blog.openshift.com/tag/big-data/feed/';
-  var numItems = 10;
-  var blogFeedContainer = $("#blog-feed-sig");
-
-  var blogItemHtml = function(link, title, author, date, description) {
-    var blogDate = new Date(date);
-    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
-    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
-    return htmlTemplate;
-  };
-
-  $.ajax({
-    url: "https://query.yahooapis.com/v1/public/yql",
-    jsonp: "callback",
-    dataType: "jsonp",
-    data: {
-        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
-        format: "json"
-    },
-    error: function() {
-      console.log("Error occurred while getting blog RSS feed!");
-    },
-    success: function( response ) {
-      var output = '';
-      $(response.query.results.item).each(function(index, entry) {
-        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
-      });
-      blogFeedContainer.html(output);
-    },
-    complete: function() {
-      $("#blog-feed-sig .blog-article").matchHeight();
-    }
-  });
+  displayBlogPosts("https://blog.openshift.com/tag/big-data/feed/", 10, $("#blog-feed-sig"));
 });
 <% end %>
 

--- a/source/sig/_dotnet_articles.erb
+++ b/source/sig/_dotnet_articles.erb
@@ -1,38 +1,6 @@
 <% content_for :javascript do %>
 $(document).ready(function () {
-  var feedUrl = 'https://blog.openshift.com/tag/microsoft/feed/';
-  var numItems = 10;
-  var blogFeedContainer = $("#blog-feed-sig");
-
-  var blogItemHtml = function(link, title, author, date, description) {
-    var blogDate = new Date(date);
-    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
-    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
-    return htmlTemplate;
-  };
-
-  $.ajax({
-    url: "https://query.yahooapis.com/v1/public/yql",
-    jsonp: "callback",
-    dataType: "jsonp",
-    data: {
-        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
-        format: "json"
-    },
-    error: function() {
-      console.log("Error occurred while getting blog RSS feed!");
-    },
-    success: function( response ) {
-      var output = '';
-      $(response.query.results.item).each(function(index, entry) {
-        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
-      });
-      blogFeedContainer.html(output);
-    },
-    complete: function() {
-      $("#blog-feed-sig .blog-article").matchHeight();
-    }
-  });
+  displayBlogPosts("https://blog.openshift.com/tag/microsoft/feed/", 10, $("#blog-feed-sig"));
 });
 <% end %>
 

--- a/source/sig/_ml_articles.erb
+++ b/source/sig/_ml_articles.erb
@@ -1,38 +1,6 @@
 <% content_for :javascript do %>
 $(document).ready(function () {
-  var feedUrl = 'https://blog.openshift.com/tag/machine-learning/feed/';
-  var numItems = 10;
-  var blogFeedContainer = $("#blog-feed-sig");
-
-  var blogItemHtml = function(link, title, author, date, description) {
-    var blogDate = new Date(date);
-    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
-    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
-    return htmlTemplate;
-  };
-
-  $.ajax({
-    url: "https://query.yahooapis.com/v1/public/yql",
-    jsonp: "callback",
-    dataType: "jsonp",
-    data: {
-        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
-        format: "json"
-    },
-    error: function() {
-      console.log("Error occurred while getting blog RSS feed!");
-    },
-    success: function( response ) {
-      var output = '';
-      $(response.query.results.item).each(function(index, entry) {
-        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
-      });
-      blogFeedContainer.html(output);
-    },
-    complete: function() {
-      $("#blog-feed-sig .blog-article").matchHeight();
-    }
-  });
+  displayBlogPosts("https://blog.openshift.com/tag/machine-learning/feed/", 10, $("#blog-feed-sig"));
 });
 <% end %>
 

--- a/source/sig/_operators_articles.erb
+++ b/source/sig/_operators_articles.erb
@@ -1,38 +1,6 @@
 <% content_for :javascript do %>
 $(document).ready(function () {
-  var feedUrl = 'https://blog.openshift.com/tag/operators/feed/';
-  var numItems = 10;
-  var blogFeedContainer = $("#blog-feed-sig");
-
-  var blogItemHtml = function(link, title, author, date, description) {
-    var blogDate = new Date(date);
-    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
-    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
-    return htmlTemplate;
-  };
-
-  $.ajax({
-    url: "https://query.yahooapis.com/v1/public/yql",
-    jsonp: "callback",
-    dataType: "jsonp",
-    data: {
-        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
-        format: "json"
-    },
-    error: function() {
-      console.log("Error occurred while getting blog RSS feed!");
-    },
-    success: function( response ) {
-      var output = '';
-      $(response.query.results.item).each(function(index, entry) {
-        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
-      });
-      blogFeedContainer.html(output);
-    },
-    complete: function() {
-      $("#blog-feed-sig .blog-article").matchHeight();
-    }
-  });
+  displayBlogPosts("https://blog.openshift.com/tag/operators/feed/", 10, $("#blog-feed-sig"));
 });
 <% end %>
 

--- a/source/sig/_ops_articles.erb
+++ b/source/sig/_ops_articles.erb
@@ -1,38 +1,6 @@
 <% content_for :javascript do %>
 $(document).ready(function () {
-  var feedUrl = 'https://blog.openshift.com/tag/operations/feed/';
-  var numItems = 10;
-  var blogFeedContainer = $("#blog-feed-sig");
-
-  var blogItemHtml = function(link, title, author, date, description) {
-    var blogDate = new Date(date);
-    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
-    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
-    return htmlTemplate;
-  };
-
-  $.ajax({
-    url: "https://query.yahooapis.com/v1/public/yql",
-    jsonp: "callback",
-    dataType: "jsonp",
-    data: {
-        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
-        format: "json"
-    },
-    error: function() {
-      console.log("Error occurred while getting blog RSS feed!");
-    },
-    success: function( response ) {
-      var output = '';
-      $(response.query.results.item).each(function(index, entry) {
-        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
-      });
-      blogFeedContainer.html(output);
-    },
-    complete: function() {
-      $("#blog-feed-sig .blog-article").matchHeight();
-    }
-  });
+  displayBlogPosts("https://blog.openshift.com/tag/operations/feed/", 10, $("#blog-feed-sig"));
 });
 <% end %>
 

--- a/source/sig/_v3_articles.erb
+++ b/source/sig/_v3_articles.erb
@@ -1,38 +1,6 @@
 <% content_for :javascript do %>
 $(document).ready(function () {
-  var feedUrl = 'https://blog.openshift.com/tag/v3/feed/';
-  var numItems = 10;
-  var blogFeedContainer = $("#blog-feed-sig");
-
-  var blogItemHtml = function(link, title, author, date, description) {
-    var blogDate = new Date(date);
-    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
-    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
-    return htmlTemplate;
-  };
-
-  $.ajax({
-    url: "https://query.yahooapis.com/v1/public/yql",
-    jsonp: "callback",
-    dataType: "jsonp",
-    data: {
-        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
-        format: "json"
-    },
-    error: function() {
-      console.log("Error occurred while getting blog RSS feed!");
-    },
-    success: function( response ) {
-      var output = '';
-      $(response.query.results.item).each(function(index, entry) {
-        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
-      });
-      blogFeedContainer.html(output);
-    },
-    complete: function() {
-      $("#blog-feed-sig .blog-article").matchHeight();
-    }
-  });
+  displayBlogPosts("https://blog.openshift.com/tag/v3/feed/", 10, $("#blog-feed-sig"));
 });
 <% end %>
 


### PR DESCRIPTION
* Replaces the YQL RSS feed retrieval with a direct request to the
  feed URL from the client; closes #982

Note: This requires the Access-Control-Allow-Origin header to be
      present with the feed response (which has been configured
	  on the blog today)

Signed-off-by: Jiri Fiala <jfiala@redhat.com>