### PR TITLE
typo in Boston event fixed

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -98,7 +98,7 @@ gatherings:
       Red Hat Summit</a> at the <a href="https://www.signatureboston.com/BCEC" target="_blank">Boston Convention and Exhibition Center</a>!
     info_text: >-
       The OpenShift Commons Gathering brings together experts from all over the world to discuss container technologies, best practices for cloud native application developers and
-      the open source software projects that underpin the OpenShift ecosystem. The Seattle event will gather developers, devops professionals and sysadmins together to explore
+      the open source software projects that underpin the OpenShift ecosystem. The Boston event will gather developers, devops professionals and sysadmins together to explore
       the next steps in making container technologies successful and secure.
     event_footer_text: >-
       Please note: Pre-registration is required AND You must have a pass for Red Hat Summit to attend this event. To register, add the OpenShift Commons Gathering as a co-located event during your Red Hat Summit registration.


### PR DESCRIPTION
  info_text: >-
     The Boston event will gather developers, devops professionals and sysadmins together to explore
      the next steps in making container technologies successful and secure.