### PR TITLE
updated lead_text and info_text

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -17,8 +17,10 @@ gatherings:
       - label: "Early Bird"
         price: "49 USD"
     lead_text: >-
-      The Silicon Valley OpenShift Commons Gathering's Theme is Operating at Scale and features guest speakers from Red Hat, Google, Facebook, Uber, Lyft.
+      The Silicon Valley OpenShift Commons Gathering's Theme is Operating at Scale and features guest speakers from Red Hat, Google, Facebook, Uber, Splunk and Nvidia.
     info_text: >-
+      This OpenShift Commons Gathering is all about "Operating at Scale" and features guest speakers from Red Hat, Google, Facebook, Nvidia, Uber, Rook.io and more. We'll be covering all the latest innovations in Kubernetes including Operators, Container Security, Serverless, Knative, Istio and all the way down to cgroups!
+      We are also hosting 2 Hands-On Developer workshops, Kubernetes Operator Framework and Deploying and Managing OpenShift Container Storage with Rook-Ceph Operator as add-ons to this Gathering. Workshop space is limited. You can add your workshop when you purchase your ticket to the Gathering.
       The OpenShift Commons Gathering brings together experts from all over the world to discuss container technologies, best practices for cloud native application developers and
       the open source software projects that underpin the OpenShift/Kuberenetes ecosystem. The Silicon Valley event will gather developers, devops professionals and sysadmins together to explore
       the next steps in making container technologies successful and secure at scale.


### PR DESCRIPTION
The Santa Clara OpenShift Commons Gathering is all about Operating at Scale" and features guest speakers from Red Hat, Google, Facebook, Nvidia, Uber, Rook.io and more. We'll be covering all the latest innovations in Kubernetes including Operators, Container Security, Serverless, Knative, Istio and all the way down to cgroups!
We are also hosting 2 Hands-On Developer workshops, Kubernetes Operator Framework and Deploying and Managing OpenShift Container Storage with Rook-Ceph Operator as add-ons to this Gathering. Workshop space is limited. You can add your workshop when you purchase your ticket to the Gathering.