### PR TITLE
adding recent Red Hat and AWS Operators

### DIFF
--- a/data/operators.yml
+++ b/data/operators.yml
@@ -259,4 +259,14 @@ vetted_operators:
   logo: "operators/gitea.png"
   logo_link: "https://github.com/integr8ly/gitea-operator/blob/master/README.md"
   description: "An Operator that installs Gitea. Installation is performed by creating a custom resource of kind Gitea. You can uninstall Gitea by removing this resource. The Operator will also watch all Gitea resources and reinstall them if they are deleted."    
-    
+- title: "Kubernetes Federation"
+  link: "https://www.operatorhub.io/operator/federationv2-community.v0.0.2"
+  logo: "operators/operatoravatar.png"
+  logo_link: "https://www.operatorhub.io/operator/federationv2-community.v0.0.2"
+  description: "Kubernetes Federation is a tool to sync (aka "federate") a set of Kubernetes objects from a "source" into a set of other clusters. Common use-cases include federating Namespaces across all of your clusters or rolling out an application across several geographically distributed clusters.."    
+- title: "AWS Service Operator"
+  link: "https://www.operatorhub.io/operator/aws-service-operator.v0.0.1"
+  logo: "operators/aws.png"
+  logo_link: "https://www.operatorhub.io/operator/aws-service-operator.v0.0.1"
+  description: "The AWS Service Operator allows you to manage AWS resources using Kubernetes Custom Resource Definitions. Using the AWS Service Operator enables a gitops workflow to drive your infrastructure to the desired state leveraging Kubernetes Custom Resource Definitions (CRD), the Kubernetes internal control loop, and AWS CloudFormation orchestration."    
+  


### PR DESCRIPTION
operatoravatar.png

- title: "AWS Service Operator"
  link: "https://www.operatorhub.io/operator/aws-service-operator.v0.0.1"
  logo: "operators/operatoravatar.png"
  logo_link: "https://www.operatorhub.io/operator/aws-service-operator.v0.0.1"
  description: "The AWS Service Operator allows you to manage AWS resources using Kubernetes Custom Resource Definitions. Using the AWS Service Operator enables a gitops workflow to drive your infrastructure to the desired state leveraging Kubernetes Custom Resource Definitions (CRD), the Kubernetes internal control loop, and AWS CloudFormation orchestration."