### PR TITLE
ias_blue_logo_wp.png

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -1348,3 +1348,6 @@ sponsors:
   - name: "arrow-helsinki"
     link: "https://ecs-fi.arrow.com"
     logo: "commons-logos/arrow-helsinki.png"
+  - name: "IAS"
+    link: "https://iarchive.com/"
+    logo: "commons-logos/ias_blue_logo_wp.png"  


### PR DESCRIPTION
  - name: "IAS"
    link: "https://iarchive.com/"
    logo: "commons-logos/ias_blue_logo_wp.png"