### PR TITLE
sig: define minimal operator logo heign

### DIFF
--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -801,7 +801,7 @@ ul.operators.list {
     .logo {
       display: block;
       text-align: left;
-      vertical-align: middle;
+      min-height: 40px;
     }
 
     img {

--- a/source/sig/_operator_list.erb
+++ b/source/sig/_operator_list.erb
@@ -1,15 +1,17 @@
 <li data-operatorTitle="<%= operator_list.title.downcase %>">
-  <div class="col-md-2 col-xs-12 logo">
-    <a href="<%= operator_list.logo_link.presence ? operator_list.logo_link : operator_list.link %>" title="<%= operator_list.title %> logo"  target="_blank">
-      <%= image_tag operator_list.logo, :alt => operator_list.title %>
-    </a>
+  <div class="row">
+    <div class="col-md-2 col-xs-12 logo">
+      <a href="<%= operator_list.logo_link.presence ? operator_list.logo_link : operator_list.link %>" title="<%= operator_list.title %> logo"  target="_blank">
+        <%= image_tag operator_list.logo, :alt => operator_list.title %>
+      </a>
+    </div>
+    <div class="col-md-10 col-xs-12 participant-name">
+      <%= link_to operator_list.title, operator_list.link, :target => "_blank" %>
+    </div>
+    <% if operator_list.description.presence %>
+    <div class="col-md-10 col-xs-12">
+      <p class="description"><%= operator_list.description %></p>
+    </div>
+    <% end %>
   </div>
-  <div class="col-md-10 col-xs-12 participant-name">
-    <%= link_to operator_list.title, operator_list.link, :target => "_blank" %>
-  </div>
-  <% if operator_list.description.presence %>
-  <div class="col-md-10 col-xs-12">
-    <p class="description"><%= operator_list.description %></p>
-  </div>
-  <% end %>
 </li>


### PR DESCRIPTION
* Defines minimal operator logo div height (40px) to ensure correct
  description indentation description for slimmer logos; closes #1081

Signed-off-by: Jiri Fiala <jfiala@redhat.com>