### PR TITLE
gatherings: add speaker's company in schedule

### DIFF
--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -1061,6 +1061,10 @@ margin: 0 20px;
 }
 .schedule-list {
 	padding: 0 20px;
+
+	p {
+		margin: 0;
+	}
 }
 .schedule-list-border-left {
 	border-left:2px solid #eee;

--- a/source/gatherings/template.html.erb
+++ b/source/gatherings/template.html.erb
@@ -265,11 +265,17 @@ description:  The OpenShift Commons community gets together and share experience
                   <div class="row schedule-list">
                     <div class="col-xs-5 col-sm-2 text-center"><%= session.local_time %></div>
                     <div class="col-xs-7 col-sm-10 schedule-list-border-left"><%= session.session_name %>
-                    <% if session.speakers.presence %>
-                      <% session.speakers.each do |speaker| %>
-                      | <a href="#<%= speaker.id %>"><%= data.gatherings.speakers.find{ |spkr| speaker.id == spkr.id }.name %></a>&nbsp;
+                      <% if session.speakers.presence %>
+                        <div class="schedule-speakers"><p>
+                        <% session.speakers.each_with_index do |speaker, i| %>
+                        <% spkr = data.gatherings.speakers.find{ |spkr| speaker.id == spkr.id } %>
+                        <% if i > 0 %>
+                        &nbsp;|&nbsp;
+                        <% end %>
+                        <a href="#<%= speaker.id %>"><%= spkr.name %><% if spkr.company.presence && spkr.company.length > 0 %> (<%= spkr.company %>)<% end %></a>
+                        <% end %>
+                        </p></div>
                       <% end %>
-                    <% end %>
                     </div>
                   </div>
                   <%= "<hr>" unless index == gathering.schedule.size - 1 %>


### PR DESCRIPTION
@dmueller2001, it looks like the speaker's company is important to mention in the agenda, which is taken care of by this automatically. It allows avoiding duplicate company mentions in the speaker section.
- Speaker names are now listed below the session title
- If a speaker and their company are defined, the company name appears next to their name in the schedule section and the speaker section is unchanged

The schedule would now look similarly to this:
![image](https://user-images.githubusercontent.com/14938461/55459435-d6c09200-55ef-11e9-87dc-4b7f9f736e95.png)

If this is something that you aim to achieve, please merge this one.