### PR TITLE
remove static blog posts section

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -75,16 +75,12 @@ description:  Where users, partners, customers, and contributors come together t
   <div class="info_resalt no-bottom">
     <div class="info_vertical">
       <h1>
-        Commons
-        <span>Blog Articles</span>
+        OpenShift Commons
+        <span>in the News</span>
       </h1>
     </div>
     <div class="container wow fadeInUp padding_bottom">
       <div class="row-fluid">
-        <div class="col-md-8 col-xs-12">
-            <p class="lead">The OpenShift Blog is full of great content. Take a look at our top three recommended blog posts.</p>
-          <%= partial "featured_articles", :object => data.featured_blogs.blogs %>
-        </div>
         <div class="col-md-4 col-xs-12" id="blog-feed-wrapper">
           <div class="row">
             <div class="col-md-12">


### PR DESCRIPTION
remove static blog posts section
re-insert at line 84

        <div class="col-md-8 col-xs-12">
            <p class="lead">The OpenShift Blog is full of great content. Take a look at our top three recommended blog posts.</p>
          <%= partial "featured_articles", :object => data.featured_blogs.blogs %>
        </div>