### PR TITLE
sig: energy breadcrumb and articles

### DIFF
--- a/source/sig/OpenShiftEnergy.html.erb
+++ b/source/sig/OpenShiftEnergy.html.erb
@@ -23,7 +23,7 @@ description: The principal purpose of the Energy Special Interest Group is to di
           </li>
           <li>/</li>
           <li>
-            <a href="/sig/OpenshiftEnergy.html">OpenShift Energy SIG</a>
+            <a href="/sig/OpenShiftEnergy.html">OpenShift Energy SIG</a>
           </li>
         </ul>
       </div>
@@ -64,13 +64,14 @@ description: The principal purpose of the Energy Special Interest Group is to di
   <div class="row info_title wow fadeInUp">
     <div class="info_vertical animated">
       <h1>
-        OpenShift Energy
+        OpenShift
         <span>Articles</span>
       </h1>
     </div>
   </div>
   <div class="container wow fadeInUp">
     <div class="row-fluid">
+      <%= partial "sig/ecosystem_articles" %>
     </div>
   </div>
 </section>

--- a/source/sig/_ecosystem_articles.erb
+++ b/source/sig/_ecosystem_articles.erb
@@ -1,0 +1,13 @@
+<% content_for :javascript do %>
+$(document).ready(function () {
+  displayBlogPosts("https://blog.openshift.com/category/openshift-ecosystem/feed/", 10, $("#blog-feed-sig"));
+});
+<% end %>
+
+<div id="blog-feed-sig">
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <i class="fa fa-cog fa-spin fa-2x" aria-hidden="true"></i>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
* updates the Energy SIG page with the correct breadcrumb link
* adds the "OpenShift Ecosystem" category feed and uses it on the
  Energy SIG page
* closes #1218

Signed-off-by: Jiri Fiala <jfiala@redhat.com>