### PR TITLE
change text for SF landing page blurb

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -17,12 +17,9 @@ gatherings:
     - label: "Early Bird"
       price: "49 USD"
   lead_text: >-
-    This Bay Area OpenShift Commons Gathering focus is on Enabling Machine Learning and AI workloads on OpenShift is co-located with ODSC/West and features guest speakers from accross the ML/AI ecosystem.
+    The OpenShift Commons Gathering will be held in San Francisco, California, co-located with ODSC/West and features guest speakers from accross the AI/ML ecosystem.
   info_text: >-
-    This OpenShift Commons Gathering is all about "Artifical Intelligence and Machine Learning on OpenShift" and features guest speakers from Red Hat and more. We'll be covering all the latest innovations in running ML & AI workloads on Kubernetes !
-    The OpenShift Commons Gathering brings together experts from all over the world to discuss container technologies, best practices for cloud native application developers and
-    the open source software projects that underpin the OpenShift/Kuberenetes ecosystem. The Silicon Valley event will gather developers, devops professionals and sysadmins together to explore
-    the next steps in making container technologies successful and secure at scale.
+    The OpenShift Commons Gatherings bring together experts from all over the world to discuss container technologies, best practices for cloud native application developers and the open source software projects that underpin the OpenShift/Kubernetes ecosystem. The Bay Area event will focus on enabling Machine Learning and AI workloads on OpenShift and will feature guest speakers from across the AI/ML ecosystem and Red Hat. 
   invite_link: "https://docs.google.com/forms/d/e/1FAIpQLSfHDndcqfnU8y6X58e0GbfqHNxWPrX1qg2REH9tin-zqjJSkw/viewform"
   sponsors:
   sponsoring_URL: "https://openshiftgathering.com/openshiftgathering_sponsors_application_sanfrancisco"


### PR DESCRIPTION
The OpenShift Commons Gatherings bring together experts from all over the world to discuss container technologies, best practices for cloud native application developers and the open source software projects that underpin the OpenShift/Kubernetes ecosystem. The Bay Area event will focus on enabling Machine Learning and AI workloads on OpenShift and will feature guest speakers from across the AI/ML ecosystem and Red Hat.