### PR TITLE
Change London Commons talk at 11.45

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -121,7 +121,7 @@ gatherings:
     - local_time: "11:20 am"
       session_name: "OpenShift Case Story"
     - local_time: "11:45 am"
-      session_name: "OpenShift Case Study @ TBD"
+      session_name: "Future Finance Data Innovations with Open Banking and PSD2"
     - local_time: "12:30 pm"
       session_name: "Lightning Talks"
     - local_time: "1:00 pm"


### PR DESCRIPTION
change the 11.45 talk in London Commons to Future Finance Data Innovations with Open Banking and PSD2
session_name: "Future Finance Data Innovations with Open Banking and PSD2"