### PR TITLE
update moscone address & link for Red Hat Summit 2020

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -73,8 +73,8 @@ gatherings:
   google_maps_URL: >-
     <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d11901783.237823999!2d-130.89998018536667!3d43.25752449035873!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8085807ded297e89%3A0xd9553880aa393c6c!2sMoscone%20Center!5e0!3m2!1sen!2sca!4v1569532691405!5m2!1sen!2sca" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
   venue: "Moscone Convention and Exhibition Center"
-  venue_URL: "https://www.marriott.com/hotels/travel/bosow-the-westin-boston-waterfront/"
-  venue_address: "425 Summer Street Boston, Massachusetts USA"
+  venue_URL: "http://www.moscone.com/site/do/index"
+  venue_address: "747 Howard St, San Francisco, CA USA"
   calendar_event_URL:
   registration_text: ""
   registration_URL: "https://reg.summit.redhat.com/"


### PR DESCRIPTION
747 Howard St, San Francisco, CA 94103, United States