### PR TITLE
gatherings: support different sponsorship levels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,8 @@ gatherings:
     invite_link: "" (optional; a link to invite a friend)
     sponsors: (optional; sponsors are searched by name in participants.yml and in the sponsor list below)
       - name: "sponsor"
+        level: 1 (optional; this can be omitted if all sponsors are to be rendered in the same group, defines group display order)
+        label: "Main Sponsor" (optional; sponsor group label; use plural form, if there are multiple sponsors in the same group)
     sponsoring_URL: "foo" (optional; if present renders a button for sponsor registration)
     sponsor_button_text: >- (optional; if present, overrides the sponsor application button text)
       Apply to be a sponsor

--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -169,12 +169,26 @@ gatherings:
   invite_link: "https://docs.google.com/forms/d/e/1FAIpQLSfHDndcqfnU8y6X58e0GbfqHNxWPrX1qg2REH9tin-zqjJSkw/viewform"
   sponsors:
     - name: "Aqua Security"
+      label: "Co-Host"
+      level: 1
     - name: "Crunchy"
+      label: "Table Sponsors"
+      level: 3
     - name: "Portworx"
+      label: "Table Sponsors"
+      level: 3
     - name: "Sysdig"
+      label: "Reception Sponsor"
+      level: 2
     - name: "StorageOS"
+      label: "Table Sponsors"
+      level: 3
     - name: "Snyk"
+      label: "Table Sponsors"
+      level: 3
     - name: "Accenture"
+      label: "Table Sponsors"
+      level: 3
   sponsoring_URL: "https://openshiftgathering.com/openshiftgathering_sponsors_application_london"
   schedule:
     - local_time: "8:00 am"

--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -1012,19 +1012,37 @@ padding: 20px 0px;
 text-align: left;
 box-shadow: 0 1px 2px rgba(0,0,0,0.16), 0 1px 2px rgba(0,0,0,0.23);
 }
-.sponsor-height {
-	align-items: center;
+
+.sponsor-heading {
+	border-bottom: 1px solid #cdcdcd;
+}
+
+.sponsor-group {
+	border-bottom: 1px solid #cdcdcd;
 	display: flex;
-	justify-content: center;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-around;
+	width: 100%;
+}
+
+.sponsor {
+	display: inline-block;
 	height: 160px;
+	min-width: 240px;
+	flex: auto;
+	text-align: center;
 
 	img {
-		padding:0px;
-		margin-left:auto;
-		margin-right:auto;
-		max-width:140px;
 		height: auto;
+		margin: auto;
+		max-width:140px;
+		padding:0px;		
+		position: relative;
 		width: 100%;
+		top: 50%;
+  		transform: translate(0,-50%);
 	}
 }
 .sponsoring-invite.obsolete {
@@ -1083,6 +1101,11 @@ margin: 0 20px;
 
 	&>.event-footer-text {
 	  padding-top: 40px;
+	}
+
+	.sponsor-level-label h4 {
+		// border-top: 1px solid black;
+		padding: 25px 0 0;
 	}
 }
 .section-gathering-secondary {
@@ -1209,7 +1232,7 @@ position:relative;
 }
 
 /*  SelectNav Short Main Menu Navigation (Gathering pages only) -----------------------------*/
-.selectnav, {
+.selectnav {
 	display: block;
 	border-radius: 5px;
 	margin:0;
@@ -1237,7 +1260,7 @@ position:relative;
 	}
 }
 .layout-boxed .selectnav_menu,
-.layout-boxed-margin .selectnav_menu,{
+.layout-boxed-margin .selectnav_menu {
 	max-width: 1230px;
 }
 
@@ -1283,7 +1306,7 @@ position:relative;
 	}
 }
 .layout-boxed .gathering_menu,
-.layout-boxed-margin .gathering_menu,{
+.layout-boxed-margin .gathering_menu {
 	max-width: 1230px;
 }
 @media (max-width: 980px) {

--- a/source/gatherings/template.html.erb
+++ b/source/gatherings/template.html.erb
@@ -210,27 +210,53 @@ description:  The OpenShift Commons community gets together and share experience
 <% if gathering.sponsors.presence %>
 <div id="gathering-sponsor"></div>
 <section class="section-gathering">
-    <div class="container text-center">
-        <div class="row container text-center">
-            <h3><%= gathering.headers.presence && gathering.headers.sponsors.presence ? gathering.headers.sponsors : 'Sponsors' %></h3>
-            <% if gathering.sponsoring_URL.presence && gathering.sponsoring_URL.length > 0 %>
-            <p class="text-center sponsoring-invite obsoletes">Interested in sponsoring OpenShift Commons Gathering?
-              <a href="<%= gathering.sponsoring_URL %>" target="_blank">Apply here.</a>
-            </p>
+    <div class="container">
+        <div class="row text-center sponsor-heading">
+          <h3><%= gathering.headers.presence && gathering.headers.sponsors.presence ? gathering.headers.sponsors : 'Sponsors' %></h3>
+          <% if gathering.sponsoring_URL.presence && gathering.sponsoring_URL.length > 0 %>
+          <p class="text-center sponsoring-invite obsoletes">Interested in sponsoring OpenShift Commons Gathering?
+            <a href="<%= gathering.sponsoring_URL %>" target="_blank">Apply here.</a>
+          </p>
+          <% end %>
+        </div>
+          <% if gathering.sponsors[1].label.presence && gathering.sponsors[1].level.presence %>
+            <%# sponsors with variable levels %>
+            <% gathering.sponsors.map { |sponsor| sponsor.level }.uniq.sort.each do |sponsor_level| %>
+            <%# iterate through numerical sponsor levels, rendering the lowest number as the first group %>
+              <% sample_sponsor = gathering.sponsors.find { |sponsor| sponsor.level == sponsor_level } %>
+                <div class="row sponsor-level-label">
+                  <div class="col-12 text-center">
+                    <h4><%= sample_sponsor.label %></h4>
+                  </div>
+                </div>  
+                <%# iterate through group level memebers %>
+                  <div class="sponsor-group">
+                  <% gathering.sponsors.find_all { |sponsor| sponsor.level == sponsor_level }.each do |s| %>
+                    <!-- Sponsor -->
+                    <div class="sponsor">
+                      <% sponsor = data.participants.participants.find{ |participants| s.name == participants.name } || data.sponsors.sponsors.find{ |sponsors| s.name == sponsors.name } %>
+                      <a href = "<%= sponsor.link %>" target = "_blank">
+                        <%= image_tag sponsor.logo, :alt => sponsor.name %>
+                      </a>
+                    </div>
+                  <% end %>
+                  </div>
             <% end %>
+            <%# The "Your logo here?" is not rendered as it's unclear which level(s) this should be advertised in. %>
+          <% else %>
+            <%# uniform level sponsors %>
+            <div class="sponsor-group">
             <% gathering.sponsors.each do |sponsor| %>
-              <!--Sponsor -->
-              <div class="sponsor sponsor-height col-xs-6 col-md-3">
-                <div class="panel-body">
-                  <% sponsor = data.participants.participants.find{ |participants| sponsor.name == participants.name } || data.sponsors.sponsors.find{ |sponsors| sponsor.name == sponsors.name } %>
-                  <a href = "<%= sponsor.link %>" target = "_blank">
-                    <%= image_tag sponsor.logo, :alt => sponsor.name %>
-                  </a>
-                </div>
+              <!-- Sponsor -->
+              <div class="sponsor">
+                <% sponsor = data.participants.participants.find{ |participants| sponsor.name == participants.name } || data.sponsors.sponsors.find{ |sponsors| sponsor.name == sponsors.name } %>
+                <a href = "<%= sponsor.link %>" target = "_blank">
+                  <%= image_tag sponsor.logo, :alt => sponsor.name %>
+                </a>
               </div>
             <% end %>
             <% if gathering.sponsoring_URL.presence && gathering.sponsoring_URL.length > 0 %>
-            <div class="sponsor sponsor-height col-xs-6 col-md-3 sponsoring-invite obsoletes">
+            <div class="sponsor sponsoring-invite obsoletes">
               <div class="panel-body">
                 <a href = "<%= gathering.sponsoring_URL %>" target = "_blank" class="obsoletes">
                   <strong>Your logo here?</strong>
@@ -238,7 +264,8 @@ description:  The OpenShift Commons community gets together and share experience
               </div>
             </div>
             <% end %>
-        </div><!-- /.row -->
+            </div>
+          <% end %>
     </div><!-- /.container -->
 </section>
 <% end %>


### PR DESCRIPTION
* Allows defining different sponsorship levels in the `gatherings.yml`
* Sponsors of the same level are grouped under customized labels
* Adjusts horizontal and vertical alignment of the sponsor logos
* Closes #1677

Signed-off-by: Jiri Fiala <jfiala@redhat.com>