### PR TITLE
gatherings: adjust workshop tab ordering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ is assumed that such a session belongs into all tracks (that can be used for eve
 order of individual track tabs is based on order of occurence when the track appears in the schedule for the first time, in the `gatherings.yml`,
 irrelevant of the actual time of that session (sessions themselves are ordered chronologically in the rendered schedule though).
 The workshops defined under the `workshops` section render as individual tabs right after tracks in the schedule area. The order of
-the workshop tabs is based on the start time of those workshops.
+workshop tabs is based on the order of appearance of those workshops in the `gatherings.yml` file.
 
 **Speakers**  
 Speaker details that are referenced by `id` in the schedule are kept in this form:

--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -60,7 +60,6 @@ gatherings:
       session_name: "Case Study: OpenShift @ Dutch Courts"
       speakers:
         - id: "jan_kappert"
-      
     - local_time: "12:50 pm"
       session_name: "Lightning Talk: IBM Cloud"  
     - local_time: "1:00 pm"

--- a/source/gatherings/template.html.erb
+++ b/source/gatherings/template.html.erb
@@ -311,12 +311,12 @@ description:  The OpenShift Commons community gets together and share experience
                   <% else %>
                   <%# only a single track, but at least one workshop too %>
                     <li class="active">
-                      <a class="schedule-tab-link" data-toggle="tab" href="#schedule-only-tab"><i class="fa fa-calendar"></i> Schedule</a>
+                      <a class="schedule-tab-link" data-toggle="tab" href="#schedule-only-tab"><i class="fa fa-calendar"></i> Main Stage</a>
                     </li>
                   <% end %>
                   <%# iterate through workshops %>
                   <% if (gathering.workshops.presence && gathering.workshops.length > 0) %>
-                    <% gathering.workshops.sort_by{ |w| w.start_time.to_time }.each do |workshop| %>
+                    <% gathering.workshops.each do |workshop| %>
                     <li>
                       <a class="schedule-tab-link" data-toggle="tab" href="#<%= workshop.title.gsub(/[^0-9A-Za-z]/, "") %>"><i class="fa fa-cogs"></i> <%= workshop.title.to_s %></a>
                     </li>
@@ -391,7 +391,7 @@ description:  The OpenShift Commons community gets together and share experience
                   <% end %>
                   <%# workshop tab content; a workshop tab is never first %>
                   <% if (gathering.workshops.presence && gathering.workshops.length > 0) %>
-                    <% gathering.workshops.sort_by{ |w| w.start_time.to_time }.each do |workshop| %>
+                    <% gathering.workshops.each do |workshop| %>
                     <div id="<%= workshop.title.gsub(/[^0-9A-Za-z]/, "") %>" class="schedule-tab tab-pane fade in">
                       <div class="workshop-card">
                         <div class="workshop-time">


### PR DESCRIPTION
* The workshop tabs order is now based on their appearance in the
  `gatherings.yml` file; chronological ordering is no longer enforced.
  (Schedule sessions are still ordered by start time.)
* The hardcoded tab title for a single track schedule with workshops is
  updated to *"Main Stage"*.

Requested-by: Morgan
Signed-off-by: Jiri Fiala <jfiala@redhat.com>