### PR TITLE
gatherings: support virtual locations

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -5,12 +5,8 @@ gatherings:
   date: "2020-03-27"
   time: "9:00 am - 5:00 pm"
   location: "Important OSCG Amsterdam 2020 Update. Please Read."
-  google_maps_URL: >-
-    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2438.007984043944!2d4.919547115959823!3d52.334001257749!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c60bd1f888758f%3A0x6d537b27986086d!2sPostillion%20Convention%20Center%20Amsterdam!5e0!3m2!1sen!2scz!4v1581510029984!5m2!1sen!2scz" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
   venue: "Virtual Gathering"
-  venue_URL: "https://www.postillionhotels.com/en-gb/conferenties-events/amsterdam"
-  venue_address: ""
-  calendar_event_URL:
+  calendar_event_URL: ""
   registration_text: "Register for the Virtual Gathering Now!"
   registration_URL: "https://www.redhat.com/en/events/webinar/openshift-commons-gathering"
   pricing:

--- a/source/gatherings/template.html.erb
+++ b/source/gatherings/template.html.erb
@@ -278,7 +278,9 @@ description:  The OpenShift Commons community gets together and share experience
             <div class="container">
                 <h3 class="text-center"><%= gathering.headers.presence && gathering.headers.schedule.presence ? gathering.headers.schedule : 'Schedule' %></h3><br>
                 <p class="text-center">
-                  <%= gathering.schedule_leadin.presence ? gathering.schedule_leadin : 'The day will have a mix of keynotes, panels, ted-style talks, SIG break-out sessions, plenty of time to network over local craft beers and be continuously fueled by local baristas.' %>
+                  <%= gathering.schedule_leadin.presence ? gathering.schedule_leadin : 'The OpenShift Commons Gatherings bring together experts from all over the world 
+                  to discuss container technologies, best practices for cloud native application developers and the open source software projects that underpin the OpenShift 
+                  ecosystem. This Gathering will gather developers, DevOps professionals, and sysadmins together to explore the next steps in making container technologies successful and secure.' %>
                 </p>
                 <br>
                 <p class="text-center">
@@ -539,6 +541,7 @@ description:  The OpenShift Commons community gets together and share experience
         <br /><%= gathering.location %>
         <br><br>
       </p>
+      <% if (gathering.google_maps_URL.presence && gathering.google_maps_URL.lenght > 0) || (gathering.venue_address.presence && gathering.venue_address.lenght > 0) %>
       <div class="map-box">
         <% if gathering.google_maps_URL.presence && gathering.google_maps_URL.length > 0 %>
         <%= gathering.google_maps_URL.gsub(/width="[0-9%]*"/, 'width="100%"').gsub(/height="[0-9%]*"/, 'height="450"') %>
@@ -546,6 +549,7 @@ description:  The OpenShift Commons community gets together and share experience
         <iframe src="https://www.google.com/maps?q=<%= ERB::Util.url_encode(gathering.venue + "," + gathering.location) %>&output=embed" width="100%" height="450" frameborder="0" allowfullscreen=""></iframe>
         <% end %>
       </div>
+      <% end %>
     </div><!-- /.row-fluid -->
   </div><!-- /.container-fluid -->
 </section>


### PR DESCRIPTION
* Makes the google map optional (only if there is venue address or the
  map URl defined), allowing to specify a virtual event.
* Updates the default schedule lead-in text; closes #1741

Signed-off-by: Jiri Fiala <jfiala@redhat.com>