### PR TITLE
gatherings: fixes the map display logic

### DIFF
--- a/data/gatherings.yml
+++ b/data/gatherings.yml
@@ -103,11 +103,8 @@ gatherings:
   date: "2020-04-27"
   time: "9:00 am - 8:00 pm"
   location: "Now a Day Zero event co-located with the Virtual Red Hat Summit"
-  google_maps_URL: >-
-    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3153.2437246169225!2d-122.40287868439188!3d37.784327619382296!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8085807ded297e89%3A0xd9553880aa393c6c!2sMoscone%20Center!5e0!3m2!1sen!2scz!4v1581515769487!5m2!1sen!2scz" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
   venue: "Virtual"
   venue_URL: "https://www.redhat.com/en/summit"
-  venue_address: "Raleigh, NC USA"
   calendar_event_URL:
   registration_text: "Register Today!"
   registration_URL: "https://reg.summit.redhat.com/account/login?signin=189042c2327dcf3c98e56dd7d9c268d5"

--- a/source/gatherings/template.html.erb
+++ b/source/gatherings/template.html.erb
@@ -535,7 +535,7 @@ description:  The OpenShift Commons community gets together and share experience
         <% else %>
           <strong><%= gathering.venue %></strong>
         <% end %>
-        <% if gathering.venue_URL.presence && gathering.venue_address.length > 0 %>
+        <% if gathering.venue_address.presence && gathering.venue_address.length > 0 %>
           <%= "<br />" + gathering.venue_address %>
         <% end %>
         <br /><%= gathering.location %>


### PR DESCRIPTION
* The map display logic for virtual gatherings is fixed (checking
  venue_address presence and length now)
* Summit gathering venue address and Google map link are removed

Signed-off-by: Jiri Fiala <jfiala@redhat.com>