### PR TITLE
events: remove an obsolete v3 reference

### DIFF
--- a/source/blog.html.erb
+++ b/source/blog.html.erb
@@ -70,7 +70,7 @@ description: Blog posts from OpenShift Commons.
           <ul class="list">
             <li>
               <i class="fa fa-check"></i>
-              OpenShift 3
+              OpenShift
             </li>
             <li>
               <i class="fa fa-check"></i>

--- a/source/events.html.erb
+++ b/source/events.html.erb
@@ -61,7 +61,7 @@ description: Supporting quotes from OpenShift Commons participants.
           <ul class="list">
             <li>
               <i class="fa fa-check"></i>
-              OpenShift 3
+              OpenShift
             </li>
             <li>
               <i class="fa fa-check"></i>

--- a/source/sig/OpenshiftImageBuilders.html.erb
+++ b/source/sig/OpenshiftImageBuilders.html.erb
@@ -1,6 +1,6 @@
 ---
 title: OpenShift Image Builders Special Interest Group
-description: The principal purpose of the OpenShift 3 Special Interest Group is to collaborate and discuss Best Practices for building and maintaining Images for use with OpenShift.
+description: The principal purpose of the OpenShift Special Interest Group is to collaborate and discuss Best Practices for building and maintaining Images for use with OpenShift.
 ---
 
 <% content_for :header do %>


### PR DESCRIPTION
* Removes the OpenShift v3 (only) reference from the Briefings ->
  Upcoming Events page + from an experimental blog page

Signed-off-by: Jiri Fiala <jfiala@redhat.com>