### PR TITLE
img: fix logo paths

### DIFF
--- a/source/layouts/_footer.erb
+++ b/source/layouts/_footer.erb
@@ -10,7 +10,7 @@
       <div class="col-md-4 col-sm-12 text-center" id="powered-by-footer">
         <div class="text">Powered by:</div>
         <a href="https://www.openshift.com/products/dedicated/" title="Powered by OpenShift Dedicated">
-          <img alt="Powered by OpenShift Online" src="img/Logo-Red_Hat-OpenShift_Dedicated-A-Reverse-RGB.svg">
+          <%= image_tag "Logo-Red_Hat-OpenShift_Dedicated-A-Reverse-RGB.svg", { :class => "logo_img", :alt => "OpenShift Dedicated" } %>
         </a>
       </div>
       <div class="col-md-4 col-sm-12">

--- a/source/testimonials.html.erb
+++ b/source/testimonials.html.erb
@@ -103,7 +103,7 @@ description: Supporting quotes from OpenShift Commons participants.
           </section>
           <section class="content_info" id="IDC">
             <div class="col-md-2">
-              <img alt="" class="img-responsive" src="/img/Logo-Red_Hat-OpenShift-A-Standard-RGB.svg">
+              <%= image_tag "Logo-Red_Hat-OpenShift-A-Standard-RGB.svg", { :class => "img-responsive" } %>
             </div>
             <p>
               “The OpenShift user and partner ecosystems are incredibly vibrant, as are the open source technology communities that serve as the foundation for OpenShift and the rest of Red Hat’s product line. What we heard from customers,partners, and these communities is that they wanted a truly open community where all of these groups can intersect and help drive the future of PaaS innovation, and Red Hat is proud to facilitate development of a community to foster this broad industry collaboration.”


### PR DESCRIPTION
* Uses the `image_tag` helper to reduce image path typos

Signed-off-by: Jiri Fiala <jfiala@redhat.com>