### PR TITLE
add sponsors to Dublin

### DIFF
--- a/src/content/gatherings/dublin-22-jun-23/index.mdx
+++ b/src/content/gatherings/dublin-22-jun-23/index.mdx
@@ -17,6 +17,18 @@ event_footer_text: >-
   This Gathering will be held on Greenwich Mean Time (GMT).
 invite_link: 'https://hopin.com/events/openshift-commons-gathering-dublin'
 sponsors:
+  - name: 'Version1'
+    label: 'Premium'
+    level: 1
+  - name: 'Portworx'
+    label: 'Reception'
+    level: 2
+  - name: 'Cloudera'
+    label: 'Executive'
+    level: 3
+  - name: 'Cockroach Labs'
+    label: 'Executive'
+    level: 3
 sponsoring_URL: 'mailto:cgriffit@redhat.com'
 schedule:
   - local_time: '9:00 a.m.'


### PR DESCRIPTION
sponsors:
  - name: 'Version1'
    label: 'Premium'
    level: 1
  - name: 'Portworx'
    label: 'Reception'
    level: 2
  - name: 'Cloudera'
    label: 'Executive'
    level: 3
  - name: 'Cockroach Labs'
    label: 'Executive'
    level: 3