### PR TITLE
- name: 'eir evo' add as sponsor to dublin

### DIFF
--- a/src/content/gatherings/dublin-22-jun-23/index.mdx
+++ b/src/content/gatherings/dublin-22-jun-23/index.mdx
@@ -29,6 +29,9 @@ sponsors:
   - name: 'Cockroach Labs'
     label: 'Executive'
     level: 3
+  - name: 'eir evo'
+    label: 'Executive'
+    level: 3
 sponsoring_URL: 'mailto:cgriffit@redhat.com'
 schedule:
   - local_time: '9:00 a.m.'


### PR DESCRIPTION
line 32